### PR TITLE
fix(travel-notes): 删除游记时不再立即更新前端列表

### DIFF
--- a/myApp/src/pages/travel-notes/index.vue
+++ b/myApp/src/pages/travel-notes/index.vue
@@ -94,8 +94,6 @@ const handleDelete = (id) => {
     content: '确定要删除这篇游记吗？',
     async success(res) {
       if (res.confirm) {
-        const index = travelList.findIndex(item => item.id === id)
-        travelList.splice(index, 1)
         await Taro.request({
           url: `http://127.0.0.1:3000/api/travelogue/${id}`,
           method: 'DELETE',


### PR DESCRIPTION
删除游记时，后端返回删除成功后再从前端列表中移除。这样可以防止在后端请求失败时，前端数据已经丢失。