### PR TITLE
refactor(back): 移除 travelogueViews 接口的权限控制

### DIFF
--- a/back/src/travelogue/travelogue.controller.ts
+++ b/back/src/travelogue/travelogue.controller.ts
@@ -100,7 +100,7 @@ export class TravelogueController {
   }
 
   @Patch('travelogueViews/:id')
-  @UseGuards(AuthUserGuard)
+  // @UseGuards(AuthUserGuard)
   travelogueViews(@Param('id') id: string) {
     return this.travelogueService.travelogueViews(+id);
   }


### PR DESCRIPTION
移除了 TravelogueController 类中 travelogueViews 方法的 AuthUserGuard 守卫，相当于取消了对该接口的权限控制。这个改动可能是为了允许未授权用户也能查看旅行记录的浏览次数。